### PR TITLE
Fixed Test-UserAdminMembership so the result is correct regardless if…

### DIFF
--- a/Code snippets/Functions library.psm1
+++ b/Code snippets/Functions library.psm1
@@ -18,10 +18,9 @@ function Test-UserAdminMembership {
   .SYNOPSIS
     Returns $True when the user account running this script is a member of the local Administrators group.
   .DESCRIPTION
-    This function checks whether the current user account is a member of the local Administrators group. If the answer is positive, depending on the User Account Control configuration on this machine, this script may either be running with administrative privileges or may request it.
+    This function checks whether the current user account is a member of the local Administrators group.
   #>
-  $MyId = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-  return $MyId.Name -in $(Get-LocalGroupMember -Name Administrators).Name
+  return [Security.Principal.WindowsIdentity]::GetCurrent().Claims.Value.Contains('S-1-5-32-544')
 }
 
 function Unregister-ScheduledTaskEx {

--- a/Code snippets/Functions library.psm1
+++ b/Code snippets/Functions library.psm1
@@ -18,9 +18,10 @@ function Test-UserAdminMembership {
   .SYNOPSIS
     Returns $True when the user account running this script is a member of the local Administrators group.
   .DESCRIPTION
-    This function checks whether the current user account is a member of the local Administrators group.
+    This function checks whether the current user account is a member of the local Administrators group. If the answer is positive, depending on the User Account Control configuration on this machine, this script may either be running with administrative privileges or may request it.
   #>
-  return [Security.Principal.WindowsIdentity]::GetCurrent().Claims.Value.Contains('S-1-5-32-544')
+  $MyId = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+  return $MyId.Claims.Value.Contains('S-1-5-32-544')
 }
 
 function Unregister-ScheduledTaskEx {


### PR DESCRIPTION
Fix to the Test-UserAdminMembership function.  The current version is only checking if the current user is a direct member of local administrators.  If the user member of any groups that are in local administrators but is not a direct member, it erroneously returns false.  See the discussion @ https://smsagent.blog/2016/06/30/testing-for-local-administrator-privilege-with-powershell/.